### PR TITLE
Update DEVToken.sol

### DIFF
--- a/contracts/DEVToken.sol
+++ b/contracts/DEVToken.sol
@@ -1,9 +1,8 @@
 pragma solidity ^0.4.18;
 
 import "zeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
-import "zeppelin-solidity/contracts/token/ERC20/PausableToken.sol";
 
-contract DEVToken is PausableToken, MintableToken {
+contract DEVToken is MintableToken {
   using SafeMath for uint256;
 
   string public name = "DEVToken";
@@ -18,29 +17,10 @@ contract DEVToken is PausableToken, MintableToken {
       _;
   }
 
-  modifier validDestination(address _to) {
-      require(_to != address(owner));
-      _;
-  }
-
   /**
-   * @dev Override the pause function to ensure no one can pause after minting.
+   * @dev Mint tokens in bulk
    */
-  function pause() onlyOwner whenNotPaused canMint public {
-      super.pause();
-  }
-
-  /**
-   * @dev Make sure we cannot finish minting when paused, otherwise we are paused forever.
-   */
-  function finishMinting() onlyOwner whenNotPaused canMint public returns (bool) {
-      return super.finishMinting();
-  }
-  
-  /**
-   * @dev Mint tokens
-   */
-  function mintToken(address[] _to, uint256[] _amount)
+  function mintMany(address[] _to, uint256[] _amount)
     onlyOwner canMint public returns (bool) 
   {
       for (uint i = 0; i < _to.length; i++) {
@@ -53,7 +33,7 @@ contract DEVToken is PausableToken, MintableToken {
    * @dev Override mint, cannot mint token for the owner of contract
    */
   function mint(address _to, uint256 _amount) 
-    onlyOwner canMint validDestination(_to) public returns (bool) 
+    onlyOwner canMint public returns (bool) 
   {
     return super.mint(_to, _amount);
   }
@@ -70,7 +50,7 @@ contract DEVToken is PausableToken, MintableToken {
    * ability to transfer tokens until after transfers have been enabled.
    */
   function transfer(address _to, uint256 _value) 
-    public onlyWhenTransferEnabled validDestination(_to) returns (bool) 
+    public onlyWhenTransferEnabled returns (bool) 
   {
       return super.transfer(_to, _value);
   }
@@ -80,7 +60,7 @@ contract DEVToken is PausableToken, MintableToken {
    * ability to transfer tokens until after transfers have been enabled.
    */
   function transferFrom(address _from, address _to, uint256 _value) 
-    public onlyWhenTransferEnabled validDestination(_to) returns (bool) 
+    public onlyWhenTransferEnabled returns (bool) 
   {
       return super.transferFrom(_from, _to, _value);
   } 


### PR DESCRIPTION
With the onlyWhenTransferEnabled modifier and enableTransfer() we don't need to extend PausableToken anymore.

The validDestination modifier is superfluous.  If this was meant to prevent the contract owners to mint to the contract owner address then they can just mint to any other addresses they own anyway.

Renamed mintToken() to mintMany().